### PR TITLE
Break the handle_server_rpc loop also on empty 200s

### DIFF
--- a/honeyclient/tr069/client.py
+++ b/honeyclient/tr069/client.py
@@ -164,7 +164,7 @@ class Client:
         count = 0
         while True:
             rpc = self.messages[-1]
-            if rpc.status_code == 204:
+            if rpc.status_code == 204 or (rpc.status_code == 200 and rpc.text == ""):
                 break
             self._handle_server_rpc(rpc)
             count += 1


### PR DESCRIPTION
Observed in the wild with (what looks like) an Alcatel HDM: the last response is an empty HTTP 200 OK. Break the handle_server_rpc() loop also with this response, in addition to the 204 that already exist today.