### PR TITLE
Add a semi-dummy handler for cwmp:Download

### DIFF
--- a/honeyclient/tr069/client.py
+++ b/honeyclient/tr069/client.py
@@ -190,6 +190,8 @@ class Client:
             path, _ = rpcs.parse_get_parameter_names(rpc.text)
             params = self.device.params.all(path)
             self.get_parameter_names_response(params)
+        elif rpc_name == "cwmp:Download":
+            self.download_response()
         else:
             raise NotImplementedError(f"Unknown server RPC: {rpc_name}")
 
@@ -230,3 +232,7 @@ class Client:
     @_wrap_rpc(rpcs.make_get_parameter_names_response)
     def get_parameter_names_response(self, *args, **kwargs):
         return self.request(rpcs.make_get_parameter_names_response(*args, **kwargs))
+
+    @_wrap_rpc(rpcs.make_download_response)
+    def download_response(self, *args, **kwargs):
+        return self.request(rpcs.make_download_response(*args, **kwargs))

--- a/honeyclient/tr069/data/rpcs/__init__.py
+++ b/honeyclient/tr069/data/rpcs/__init__.py
@@ -5,7 +5,7 @@ from .get_set_parameters import (
     make_set_parameter_attributes_response,
 )
 from .inform import make_inform
-from .request_download import make_request_download
+from .request_download import make_request_download, make_download_response
 from .rpc_methods import make_get_rpc_methods
 
 __all__ = [
@@ -15,5 +15,5 @@ __all__ = [
     "make_get_parameter_values_response", "parse_get_parameter_values",
     "make_get_parameter_names_response", "parse_get_parameter_names",
     "make_set_parameter_attributes_response",
-    "make_request_download",
+    "make_request_download", "make_download_response",
 ]

--- a/honeyclient/tr069/data/rpcs/request_download.py
+++ b/honeyclient/tr069/data/rpcs/request_download.py
@@ -1,3 +1,6 @@
+import datetime
+from typing import Optional
+
 from .. import soap
 
 
@@ -24,4 +27,23 @@ def make_request_download(
                 {"".join(args)}
             </FileTypeArg>
         </cwmp:RequestDownload>
+    """)
+
+
+def make_download_response(
+        status: int = 0,
+        start_time: Optional[datetime.datetime] = None,
+        complete_time: Optional[datetime.datetime] = None
+) -> str:
+    """Create a DownloadResponse"""
+    if start_time is None:
+        start_time = datetime.datetime.now()
+    if complete_time is None:
+        complete_time = datetime.datetime.now()
+    return soap.soapify(f"""
+        <cwmp:DownloadResponse>
+            <Status>{status}</Status>
+            <StartTime>{start_time.isoformat()}</StartTime>
+            <CompleteTime>{complete_time.isoformat()}</CompleteTime>
+        </cwmp:DownloadResponse>
     """)


### PR DESCRIPTION
Craft DownloadResponses with Status=0, thus avoiding TransferCompletes etc. to all cwmp:Download requests. No way to extract the download information right now (or even download it), but this helps with the ACS handing out additional SetParameterValue etc.